### PR TITLE
Add support for build Linux opt in Docker

### DIFF
--- a/unix/opt/README.md
+++ b/unix/opt/README.md
@@ -3,7 +3,7 @@
 ### Automatic build
 
 ```bash
-sudo docker run --rm -v $(pwd):/io ubuntu:14.04 [-e GEM_SET_BRANCH='master'] /io/build-opt-unix.sh
+sudo docker run --rm -v $(pwd):/io ubuntu:14.04 /io/build-opt-unix.sh [-e GEM_SET_BRANCH='master']
 ```
 
 ### Manual build

--- a/unix/opt/README.md
+++ b/unix/opt/README.md
@@ -11,7 +11,7 @@ sudo docker run --rm -v $(pwd):/io ubuntu:14.04 /io/build-opt-unix.sh [-e GEM_SE
 ```bash
 sudo docker run --rm -t -i -v $(pwd):/io ubuntu:14.04 /bin/bash
 $ cd /io
-$ bash build-opt-unix.sh
+$ [GEM_SET_BRANCH='master'] bash build-opt-unix.sh
 ```
 
 ## LXC or bare-metal
@@ -29,5 +29,13 @@ sudo lxc-console -n ubuntu14-opt-builder
 ```bash
 $ git clone https://github.com/gem/oq-installers.git
 $ cd oq-installers/unix/opt
-$ bash build-opt-unix.sh
+$ [GEM_SET_BRANCH='master'] bash build-opt-unix.sh
 ```
+
+## Script parameters
+
+The following environment variables are understood by the script:
+
+- GEM_SET_DEBUG=<true|false>: enable debug (set -x)
+- GEM_SET_NPROC=n: it will pass 'n' to `make -j` (default is 2)
+- GEM_SET_BRANCH='branch': build the selected branch (by default is master)

--- a/unix/opt/README.md
+++ b/unix/opt/README.md
@@ -1,0 +1,24 @@
+## Run build on Docker
+
+```bash
+sudo docker run --rm -v $(pwd):/io ubuntu:14.04 /io/build-opt-unix.sh
+```
+
+## Run build on Docker manually
+
+```bash
+sudo docker run --rm -t -i -v $(pwd):/io ubuntu:14.04 /bin/bash
+$ cd /io
+$ bash build-opt-unix.sh
+```
+
+## Run build on LXC
+
+```bash
+sudo lxc-create -n ubuntu14-opt-builder -t ubuntu -- -r trusty
+sudo lxc-start -n ubuntu14-opt-builder
+sudo lxc-console -n ubuntu14-opt-builder
+$ git clone https://github.com/gem/oq-installers.git
+$ cd oq-installers/unix/opt
+$ bash build-opt-unix.sh
+```

--- a/unix/opt/README.md
+++ b/unix/opt/README.md
@@ -3,7 +3,7 @@
 ### Automatic build
 
 ```bash
-sudo docker run --rm -v $(pwd):/io ubuntu:14.04 /io/build-opt-unix.sh
+sudo docker run --rm -v $(pwd):/io ubuntu:14.04 [-e GEM_SET_BRANCH='master'] /io/build-opt-unix.sh
 ```
 
 ### Manual build

--- a/unix/opt/README.md
+++ b/unix/opt/README.md
@@ -1,10 +1,12 @@
-## Run build on Docker
+## Docker
+
+### Automatic build
 
 ```bash
 sudo docker run --rm -v $(pwd):/io ubuntu:14.04 /io/build-opt-unix.sh
 ```
 
-## Run build on Docker manually
+### Manual build
 
 ```bash
 sudo docker run --rm -t -i -v $(pwd):/io ubuntu:14.04 /bin/bash
@@ -12,12 +14,19 @@ $ cd /io
 $ bash build-opt-unix.sh
 ```
 
-## Run build on LXC
+## LXC or bare-metal
+
+### LXC bootstrap
 
 ```bash
 sudo lxc-create -n ubuntu14-opt-builder -t ubuntu -- -r trusty
 sudo lxc-start -n ubuntu14-opt-builder
 sudo lxc-console -n ubuntu14-opt-builder
+```
+
+### LXC, bare-metal Ubuntu 14.04 or macOS
+
+```bash
 $ git clone https://github.com/gem/oq-installers.git
 $ cd oq-installers/unix/opt
 $ bash build-opt-unix.sh

--- a/unix/opt/build-opt-unix.sh
+++ b/unix/opt/build-opt-unix.sh
@@ -36,18 +36,24 @@ not_supported() {
     exit 1
 }
 
+OQ_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OQ_ROOT=/tmp/build-openquake-dist
+OQ_REL=qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+OQ_PREFIX=${OQ_ROOT}/${OQ_REL}/openquake
+CLEANUP=true
+
 if [ $GEM_SET_NPROC ]; then
     NPROC=$GEM_SET_NPROC
 else
     #Everyone has at least two cores
     NPROC=2
 fi
-OQ_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OQ_ROOT=/tmp/build-openquake-dist
-OQ_REL=qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
-OQ_PREFIX=${OQ_ROOT}/${OQ_REL}/openquake
-OQ_BRANCH=master
-CLEANUP=true
+if [ $GEM_SET_BRANCH ]; then
+    OQ_BRANCH=$GEM_SET_BRANCH
+else
+    #Everyone has at least two cores
+    OQ_BRANCH=master
+fi
 
 rm -Rf $OQ_ROOT
 cd $OQ_DIR

--- a/unix/opt/build-opt-unix.sh
+++ b/unix/opt/build-opt-unix.sh
@@ -42,6 +42,7 @@ else
     #Everyone has at least two cores
     NPROC=2
 fi
+OQ_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 OQ_ROOT=/tmp/build-openquake-dist
 OQ_REL=qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
 OQ_PREFIX=${OQ_ROOT}/${OQ_REL}/openquake
@@ -49,7 +50,7 @@ OQ_BRANCH=master
 CLEANUP=true
 
 rm -Rf $OQ_ROOT
-
+cd $OQ_DIR
 
 if $(echo $OSTYPE | grep -q linux); then
     BUILD_OS='linux64'

--- a/unix/opt/build-opt-unix.sh
+++ b/unix/opt/build-opt-unix.sh
@@ -51,7 +51,6 @@ fi
 if [ $GEM_SET_BRANCH ]; then
     OQ_BRANCH=$GEM_SET_BRANCH
 else
-    #Everyone has at least two cores
     OQ_BRANCH=master
 fi
 


### PR DESCRIPTION
This PR adds instruction on how to run the opt builder inside docker and provides a small change in the script to allow run in docker from an arbitrary path.
