### PR TITLE
Split installation in multiple sections and allow upgrade

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -41,10 +41,10 @@ Microsoft Windows is not required.
 Setup of the sole `oq-engine` and `oq-hazardlib` can be done adding `--no-deps` to the command above.
 
 ### Setup OpenQuake
-- `cp -r src/oq-engine/demos ..`
-- `cp -r src/oq-engine/openquake.cfg ..`
+- `cp -r src/oq-engine/demos .`
+- `cp -r src/oq-engine/openquake.cfg .`
 - `python -m markdown src/oq-engine/README.md > README.html`
-- run NSIS:` wine makensis installer.nsi`
+- run NSIS:` wine makensis /V4 installer.nsi`
 
 ### Open issues
 

--- a/windows/nsis-installer/installer.nsi
+++ b/windows/nsis-installer/installer.nsi
@@ -101,7 +101,7 @@ Section "!OpenQuake Engine and Hazardlib" SecOQ
   File "oq-server.bat"
   File "openquake.cfg"
   SetOutPath "$INSTDIR\lib\site-packages"
-  File /r "src\python-dist\lib\site-packages\openquake*.*"
+  File /r "python-dist\lib\site-packages\openquake*.*"
   SetOutPath "$INSTDIR\demos"
   File /r /x ".gitignore" "demos\*.*"
   

--- a/windows/nsis-installer/installer.nsi
+++ b/windows/nsis-installer/installer.nsi
@@ -32,31 +32,29 @@ RequestExecutionLevel admin
 Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
 OutFile "${INSTALLER_NAME}"
 InstallDir "$PROGRAMFILES${BITNESS}\${PRODUCT_NAME}"
-ShowInstDetails show
 
 Function .onInit
- 
   ${IfNot} ${RunningX64}
       MessageBox MB_OK "A 64bit OS is required"
       Quit
   ${EndIf}
 
-  ReadRegStr $R0 HKLM \
-  "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
-  "UninstallString"
-  StrCmp $R0 "" done
+  #ReadRegStr $R0 HKLM \
+  #"Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+  #"UninstallString"
+  #StrCmp $R0 "" done
  
-  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-  "${PRODUCT_NAME} is already installed. $\n$\nClick `OK` to remove the \
-  previous version or `Cancel` to cancel this upgrade." \
-  IDOK uninst
-  Abort
+  #MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+  #"${PRODUCT_NAME} is already installed. $\n$\nClick `OK` to remove the \
+  #previous version or `Cancel` to cancel this upgrade." \
+  #IDOK uninst
+  #Abort
  
-;Run the uninstaller
-uninst:
-  ClearErrors
-  Exec $INSTDIR\uninstall.exe
-done:
+  #;Run the uninstaller
+  #uninst:
+  #  ClearErrors
+  #  Exec $INSTDIR\uninstall.exe
+  #done:
 
 FunctionEnd
 
@@ -75,46 +73,73 @@ SectionEnd
 ; SectionEnd
 
 
-Section "!${PRODUCT_NAME}" sec_app
+Section "!Core Files" SecCore
   SectionIn RO
   SetShellVarContext all
-  File ${PRODUCT_ICON}
-  SetOutPath "$INSTDIR\python2.7"
-  File /r "python-dist\python2.7\*.*"
-  SetOutPath "$INSTDIR\lib"
-  File /r "python-dist\lib\*.*"
-  File /r "checkifup.py"
-  SetOutPath "$INSTDIR\lib\site-packages\openquake"
-  File "src\__init__.py"
+
   SetOutPath "$INSTDIR"
-  
-  ; Install files
-    SetOutPath "$INSTDIR"
-      File "LICENSE.txt"
-      File "README.html"
-      File "openquake.cfg"
-      File "openquake.ico"
-      File "oq-server.bat"
-      File "oq-console.bat"
-  
-  ; Install directories
-    SetOutPath "$INSTDIR\demos"
-    File /r /x ".gitignore" "demos\*.*"
-  
-  ; Install shortcuts
-  ; The output path becomes the working directory for shortcuts
+  File ${PRODUCT_ICON}
+  File "LICENSE.txt"
+  File "README.html"
+  File "oq-console.bat"
+
   SetOutPath "$INSTDIR"
     CreateShortCut "$SMPROGRAMS\OpenQuake Engine (webui).lnk" "$INSTDIR\oq-server.bat" \
       "" "$INSTDIR\openquake.ico"
+  SetOutPath "$INSTDIR"
+
+  SetOutPath "$INSTDIR\python2.7"
+  File /r "python-dist\python2.7\*.*"
+
+  SetOutPath "$INSTDIR\lib"
+  File "checkifup.py"
+SectionEnd
+
+
+Section "!Python libraries" SecLib
+  SetShellVarContext all
+
+  SetOutPath "$INSTDIR\lib"
+  File /r "python-dist\lib\*.*"
+SectionEnd
+
+
+Section "!OpenQuake Engine and Hazardlib" SecOQ
+  SetOutPath "$INSTDIR"
+  File "oq-server.bat"
+  File "openquake.cfg"
+  SetOutPath "$INSTDIR\lib\site-packages\openquake"
+  File "src\__init__.py"
+  SetOutPath "$INSTDIR\demos"
+  File /r /x ".gitignore" "demos\*.*"
+  
+  SetOutPath "$INSTDIR"
     CreateShortCut "$SMPROGRAMS\OpenQuake Engine (console).lnk" "$INSTDIR\oq-console.bat" \
       "" "$INSTDIR\openquake.ico"
   SetOutPath "$INSTDIR"
+
+  !define OQ_INSTALLED "true"
+
+SectionEnd
+
+Section "OpenQuake Engine desktop icon" SecIcon
+  SetOutPath "$INSTDIR"
+  CreateShortCut "$DESKTOP\OpenQuake Engine (console).lnk" "$INSTDIR\oq-console.bat" \
+      "" "$INSTDIR\openquake.ico"
+  StrCmp "${OQ_INSTALLED}" "" done
   
+  CreateShortCut "$DESKTOP\OpenQuake Engine (webui).lnk" "$INSTDIR\oq-server.bat" \
+      "" "$INSTDIR\openquake.ico"
+  done:
+SectionEnd
+
+Section -post
   ; Byte-compile Python files.
   DetailPrint "Byte-compiling Python modules..."
   nsExec::ExecToLog '$INSTDIR\python2.7\python.exe -m compileall -q "$INSTDIR\lib"'
 
   WriteUninstaller $INSTDIR\uninstall.exe
+
   ; Add ourselves to Add/remove programs
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
                    "DisplayName" "${PRODUCT_NAME}"
@@ -145,13 +170,6 @@ Section "!${PRODUCT_NAME}" sec_app
   noreboot:
 SectionEnd
 
-Section "OpenQuake Engine desktop icon" sec_icon
-  SetOutPath "$INSTDIR"
-  CreateShortCut "$DESKTOP\OpenQuake Engine (webui).lnk" "$INSTDIR\oq-server.bat" \
-      "" "$INSTDIR\openquake.ico"
-  CreateShortCut "$DESKTOP\OpenQuake Engine (console).lnk" "$INSTDIR\oq-console.bat" \
-      "" "$INSTDIR\openquake.ico"
-SectionEnd
 
 Section "Uninstall"
   SetShellVarContext all
@@ -177,20 +195,131 @@ Section "Uninstall"
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 SectionEnd
 
-; Functions
 
-Function .onMouseOverSection
-    ; Find which section the mouse is over, and set the corresponding description.
-    FindWindow $R0 "#32770" "" $HWNDPARENT
-    GetDlgItem $R0 $R0 1043 ; description item (must be added to the UI)
+!ifdef VER_MAJOR & VER_MINOR & VER_REVISION & VER_BUILD
 
-;    StrCmp $0 ${sec_py} 0 +2
-;      SendMessage $R0 ${WM_SETTEXT} 0 "STR:The Python interpreter. \
-;            This is required for ${PRODUCT_NAME} to run."
+Var ReinstallPageCheck
 
-    StrCmp $0 ${sec_app} "" +2
-      SendMessage $R0 ${WM_SETTEXT} 0 "STR:The ${PRODUCT_NAME} by GEM."
-    
-    StrCmp $0 ${sec_icon} "" +2
-      SendMessage $R0 ${WM_SETTEXT} 0 "STR:The OpenQuake Engine desktop icon."
+Function PageReinstall
+
+  ReadRegStr $R0 HKLM "Software\${PRODUCT_NAME}" ""
+  ReadRegStr $R1 HKLM "${REG_UNINST_KEY}" "UninstallString"
+  ${IfThen} "$R0$R1" == "" ${|} Abort ${|}
+
+  StrCpy $R4 "older"
+  ReadRegDWORD $R0 HKLM "Software\${PRODUCT_NAME}" "VersionMajor"
+  ReadRegDWORD $R1 HKLM "Software\${PRODUCT_NAME}" "VersionMinor"
+  ReadRegDWORD $R2 HKLM "Software\${PRODUCT_NAME}" "VersionRevision"
+  ReadRegDWORD $R3 HKLM "Software\${PRODUCT_NAME}" "VersionBuild"
+  ${IfThen} $R0 = 0 ${|} StrCpy $R4 "unknown" ${|} ; Anonymous builds have no version number
+  StrCpy $R0 $R0.$R1.$R2.$R3
+
+  ${VersionCompare} ${VER_MAJOR}.${VER_MINOR}.${VER_REVISION}.${VER_BUILD} $R0 $R0
+  ${If} $R0 == 0
+    StrCpy $R1 "${PRODUCT_NAME} ${VERSION} is already installed. Select the operation you want to perform and click Next to continue."
+    StrCpy $R2 "Add/Reinstall components"
+    StrCpy $R3 "Uninstall ${PRODUCT_NAME}"
+    !insertmacro MUI_HEADER_TEXT "Already Installed" "Choose the maintenance option to perform."
+    StrCpy $R0 "2"
+  ${ElseIf} $R0 == 1
+    StrCpy $R1 "An $R4 version of ${PRODUCT_NAME} is installed on your system. It's recommended that you uninstall the current version before installing. Select the operation you want to perform and click Next to continue."
+    StrCpy $R2 "Uninstall before installing"
+    StrCpy $R3 "Do not uninstall"
+    !insertmacro MUI_HEADER_TEXT "Already Installed" "Choose how you want to install ${PRODUCT_NAME}."
+    StrCpy $R0 "1"
+  ${ElseIf} $R0 == 2
+    StrCpy $R1 "A newer version of ${PRODUCT_NAME} is already installed! It is not recommended that you install an older version. If you really want to install this older version, it's better to uninstall the current version first. Select the operation you want to perform and click Next to continue."
+    StrCpy $R2 "Uninstall before installing"
+    StrCpy $R3 "Do not uninstall"
+    !insertmacro MUI_HEADER_TEXT "Already Installed" "Choose how you want to install ${PRODUCT_NAME}."
+    StrCpy $R0 "1"
+  ${Else}
+    Abort
+  ${EndIf}
+
+  nsDialogs::Create 1018
+  Pop $R4
+
+  ${NSD_CreateLabel} 0 0 100% 24u $R1
+  Pop $R1
+
+  ${NSD_CreateRadioButton} 30u 50u -30u 8u $R2
+  Pop $R2
+  ${NSD_OnClick} $R2 PageReinstallUpdateSelection
+
+  ${NSD_CreateRadioButton} 30u 70u -30u 8u $R3
+  Pop $R3
+  ${NSD_OnClick} $R3 PageReinstallUpdateSelection
+
+  ${If} $ReinstallPageCheck != 2
+    SendMessage $R2 ${BM_SETCHECK} ${BST_CHECKED} 0
+  ${Else}
+    SendMessage $R3 ${BM_SETCHECK} ${BST_CHECKED} 0
+  ${EndIf}
+
+  ${NSD_SetFocus} $R2
+
+  nsDialogs::Show
+
 FunctionEnd
+
+Function PageReinstallUpdateSelection
+
+  Pop $R1
+
+  ${NSD_GetState} $R2 $R1
+
+  ${If} $R1 == ${BST_CHECKED}
+    StrCpy $ReinstallPageCheck 1
+  ${Else}
+    StrCpy $ReinstallPageCheck 2
+  ${EndIf}
+
+FunctionEnd
+
+Function PageLeaveReinstall
+
+  ${NSD_GetState} $R2 $R1
+
+  StrCmp $R0 "1" 0 +2 ; Existing install is not the same version?
+    StrCmp $R1 "1" reinst_uninstall reinst_done
+
+  StrCmp $R1 "1" reinst_done ; Same version, skip to add/reinstall components?
+
+  reinst_uninstall:
+  ReadRegStr $R1 HKLM "${REG_UNINST_KEY}" "UninstallString"
+
+  ;Run uninstaller
+    HideWindow
+
+    ClearErrors
+    ExecWait '$R1 _?=$INSTDIR' $0
+
+    BringToFront
+
+    ${IfThen} ${Errors} ${|} StrCpy $0 2 ${|} ; ExecWait failed, set fake exit code
+
+  reinst_done:
+
+FunctionEnd
+
+!endif
+
+
+
+
+#Function .onMouseOverSection
+#    ; Find which section the mouse is over, and set the corresponding description.
+#    FindWindow $R0 "#32770" "" $HWNDPARENT
+#    GetDlgItem $R0 $R0 1043 ; description item (must be added to the UI)
+#
+#;    StrCmp $0 ${sec_py} 0 +2
+#;      SendMessage $R0 ${WM_SETTEXT} 0 "STR:The Python interpreter. \
+#;            This is required for ${PRODUCT_NAME} to run."
+#
+#    StrCmp $0 ${sec_app} "" +2
+#      SendMessage $R0 ${WM_SETTEXT} 0 "STR:The ${PRODUCT_NAME} by GEM."
+#    
+#    StrCmp $0 ${sec_icon} "" +2
+#      SendMessage $R0 ${WM_SETTEXT} 0 "STR:The OpenQuake Engine desktop icon."
+#FunctionEnd

--- a/windows/nsis-installer/installer.nsi
+++ b/windows/nsis-installer/installer.nsi
@@ -148,7 +148,7 @@ Section -post
   IfRebootFlag 0 noreboot
     MessageBox MB_YESNO "A reboot is required to finish the installation. Do you wish to reboot now?" \
                 /SD IDNO IDNO noreboot
-      Reboot
+    Reboot
   noreboot:
 SectionEnd
 

--- a/windows/nsis-installer/installer.nsi
+++ b/windows/nsis-installer/installer.nsi
@@ -82,6 +82,9 @@ Section "!Core Files" SecCore
 
   SetOutPath "$INSTDIR\lib"
   File "checkifup.py"
+
+  SetOutPath "$INSTDIR\lib\site-packages\openquake"
+  File "src\__init__.py"
 SectionEnd
 
 
@@ -89,7 +92,7 @@ Section "!Python libraries" SecLib
   SetShellVarContext all
 
   SetOutPath "$INSTDIR\lib"
-  File /r "python-dist\lib\*.*"
+  File /r /x "openquake*" "python-dist\lib\*.*"
 SectionEnd
 
 
@@ -97,8 +100,8 @@ Section "!OpenQuake Engine and Hazardlib" SecOQ
   SetOutPath "$INSTDIR"
   File "oq-server.bat"
   File "openquake.cfg"
-  SetOutPath "$INSTDIR\lib\site-packages\openquake"
-  File "src\__init__.py"
+  SetOutPath "$INSTDIR\lib\site-packages"
+  File /r "src\python-dist\lib\site-packages\openquake*.*"
   SetOutPath "$INSTDIR\demos"
   File /r /x ".gitignore" "demos\*.*"
   
@@ -108,7 +111,6 @@ Section "!OpenQuake Engine and Hazardlib" SecOQ
   SetOutPath "$INSTDIR"
 
   !define OQ_INSTALLED "true"
-
 SectionEnd
 
 Section "OpenQuake Engine desktop icon" SecIcon

--- a/windows/nsis-installer/oq-console.bat
+++ b/windows/nsis-installer/oq-console.bat
@@ -5,6 +5,7 @@ set PATH=%mypath%\python2.7;%PATH%
 set PYTHONPATH=%mypath%\lib\site-packages
 set OQ_SITE_CFG_PATH=%mypath%\openquake.cfg
 
+doskey pip=python.exe -m pip $*
 doskey oq=python.exe -m openquake.commands.__main__ $*
 doskey oq-engine=python.exe -m openquake.commands.__main__ engine $*
 

--- a/windows/nsis-installer/oq-console.bat
+++ b/windows/nsis-installer/oq-console.bat
@@ -10,6 +10,7 @@ doskey oq=python.exe -m openquake.commands.__main__ $*
 doskey oq-engine=python.exe -m openquake.commands.__main__ engine $*
 
 echo OpenQuake environment loaded
+echo To see versions of installed software run 'pip freeze'
 echo To run OpenQuake use 'oq' and 'oq engine'
 cmd /k
 


### PR DESCRIPTION
This speeds up installation when only a part of the application needs to be upgraded (i.e. OpenQuake code).
Fixes another nasty bug with uninstall/reinstall using a different logic to detect previous versions.

Will allow, in the future, integration of more OpenQuake applications.