### PR TITLE
Add zipped demo in Windows installer

### DIFF
--- a/installers/windows/nsis/docker/Dockerfile
+++ b/installers/windows/nsis/docker/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniele Viganò <daniele@openquake.org>
 
 ARG uid=1000
 
-RUN dnf -y install wine python-markdown python-wheel wget git unzip
+RUN dnf -y install wine python-markdown python-wheel wget git zip unzip
 
 RUN useradd -u 1000 builder
 

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -46,7 +46,7 @@ cd ..
 # Get the demo and the README
 cp -r src/oq-engine/demos .
 for d in hazard risk; do
-    cd src/oq-engine/demos/${d}
+    cd demos/${d}
     for z in *; do
         zip -r ${z}.zip $z
     done

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -45,6 +45,14 @@ cd ..
 
 # Get the demo and the README
 cp -r src/oq-engine/demos .
+for d in hazard risk; do
+    cd src/oq-engine/demos/${d}
+    for z in *; do
+        zip -r ${z}.zip $z
+    done
+    cd -
+done
+
 python -m markdown src/oq-engine/README.md > README.html
 
 # Get a copy of the OQ manual if not yet available


### PR DESCRIPTION
Generate zip files for each demo to be included in the Windows installer. This is required by the WebUi