### PR TITLE
Move installers/env to Python 3.5

### DIFF
--- a/installers/unix/Dockerfile.builder
+++ b/installers/unix/Dockerfile.builder
@@ -2,14 +2,14 @@
 FROM centos:6
 MAINTAINER Daniele Viganò <daniele@openquake.org>
 
-ARG uid=107
-
 RUN yum -y upgrade && \
     yum -y groupinstall 'Development Tools' && \
-    yum -y install epel-release && \
+    yum -y install centos-release-scl epel-release && \
     yum -y install autoconf bzip2-devel curl git gzip libtool makeself \
-                   readline-devel spatialindex-devel sudo sqlite-devel tar \
-                   which xz zip zlib-devel
+                   readline-devel rh-python35 spatialindex-devel sudo \
+                   sqlite-devel tar which xz zip zlib-devel
+
+ARG uid=107
 
 RUN useradd -u $uid builder && \
 echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
@@ -17,6 +17,9 @@ echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER builder
 
 ENV HOME /home/builder
+ENV PATH=/opt/rh/rh-python35/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/rh-python35/root/usr/lib64
+
 WORKDIR ${HOME}
 
 CMD /bin/bash

--- a/installers/unix/Dockerfile.builder
+++ b/installers/unix/Dockerfile.builder
@@ -1,4 +1,5 @@
 # vi:syntax=dockerfile
+# name:centos6-builder
 FROM centos:6
 MAINTAINER Daniele Viganò <daniele@openquake.org>
 

--- a/installers/unix/env/README.md
+++ b/installers/unix/env/README.md
@@ -1,29 +1,27 @@
 ## Docker
 
-To support as most distros as possible the default build target for Linux is CentOS 6 (`$GEM_SET_VENDOR='redhat'`).
+To support as most distros as possible the default build target for Linux is CentOS 6.
 
 ### Automatic build
 
 ```bash
-sudo docker run [-e GEM_SET_BRANCH='master'] --rm -v $(pwd):/io centos:6 /io/build-pyenv-unix.sh
+sudo docker run [-e GEM_SET_BRANCH='master'] --rm -v $(pwd):/io centos6-builder /io/build-pyenv-unix.sh
 ```
 
 ### Manual build
 
 ```bash
-sudo docker run --rm -t -i -v $(pwd):/io centos:6 /bin/bash
+sudo docker run --rm -t -i -v $(pwd):/io centos6-builder /bin/bash
 $ cd /io
-$ [GEM_SET_BRANCH='master'] bash build-pyenv-unix.sh
+$ [GEM_SET_BRANCH='master'] bash /io/build-pyenv-unix.sh
 ```
 
-## Bare-metal
+## macOS
 
-### On LXC, bare-metal or macOS
+https://www.python.org/ftp/python/3.5.3/python-3.5.3-macosx10.6.pkg must be installed first
 
 ```bash
-$ git clone https://github.com/gem/oq-installers.git
-$ cd oq-installers/unix/env
-$ [GEM_SET_BRANCH='master'] [GEM_SET_VENDOR='ubuntu|redhat'] bash build-pyenv-unix.sh
+./build-pyenv-unix.sh
 ```
 
 ## Script parameters

--- a/installers/unix/env/README.md
+++ b/installers/unix/env/README.md
@@ -2,6 +2,12 @@
 
 To support as most distros as possible the default build target for Linux is CentOS 6.
 
+To reduce the workload (downloading pre-requisites) a `Dockerfile` is provided to create a builder:
+
+```bash
+sudo docker build --rm=true -t centos6-builder -f Dockerfile.builder .
+```
+
 ### Automatic build
 
 ```bash
@@ -18,7 +24,7 @@ $ [GEM_SET_BRANCH='master'] bash /io/build-pyenv-unix.sh
 
 ## macOS
 
-https://www.python.org/ftp/python/3.5.3/python-3.5.3-macosx10.6.pkg must be installed first
+Xcode and (Python 3.5)[https://www.python.org/ftp/python/3.5.3/python-3.5.3-macosx10.6.pkg] must be installed first
 
 ```bash
 ./build-pyenv-unix.sh

--- a/installers/unix/env/build-pyenv-unix.sh
+++ b/installers/unix/env/build-pyenv-unix.sh
@@ -61,12 +61,12 @@ cd $OQ_ROOT
 if $(echo $OSTYPE | grep -q linux); then
     BUILD_OS='linux64'
     if [ -f /etc/redhat-release ]; then
-        yum -y upgrade
-        yum -y install epel-release
-        yum -y install curl gcc git makeself zip
+        sudo yum -y upgrade
+        sudo yum -y install epel-release
+        sudo yum -y install curl gcc git makeself zip
         # CentOS (with SCL)
-        yum -y install centos-release-scl
-        yum -y install rh-python35
+        sudo yum -y install centos-release-scl
+        sudo yum -y install rh-python35
         export PATH=/opt/rh/rh-python35/root/usr/bin:$PATH
         export LD_LIBRARY_PATH=/opt/rh/rh-python35/root/usr/lib64
     else

--- a/installers/unix/env/build-pyenv-unix.sh
+++ b/installers/unix/env/build-pyenv-unix.sh
@@ -67,8 +67,8 @@ if $(echo $OSTYPE | grep -q linux); then
         # CentOS (with SCL)
         yum -y install centos-release-scl
         yum -y install rh-python35
-        export PATH=/opt/rh/python35/root/usr/bin:$PATH
-        export LD_LIBRARY_PATH=/opt/rh/python35/root/usr/lib64
+        export PATH=/opt/rh/rh-python35/root/usr/bin:$PATH
+        export LD_LIBRARY_PATH=/opt/rh/rh-python35/root/usr/lib64
     else
         not_supported
     fi

--- a/installers/unix/env/build-pyenv-unix.sh
+++ b/installers/unix/env/build-pyenv-unix.sh
@@ -22,6 +22,8 @@ if [ $GEM_SET_DEBUG ]; then
 fi
 set -e
 
+PYTHON=python3.5
+
 check_dep() {
     for i in $*; do
         command -v $i &> /dev/null || {
@@ -80,7 +82,7 @@ else
     not_supported
 fi
 
-/usr/bin/env python3.5 -m venv pybuild
+/usr/bin/env $PYTHON -m venv pybuild
 source pybuild/bin/activate
 
 for g in hazardlib engine;

--- a/installers/unix/env/build-pyenv-unix.sh
+++ b/installers/unix/env/build-pyenv-unix.sh
@@ -89,14 +89,19 @@ do
     git clone --depth=1 -b $OQ_BRANCH https://github.com/gem/oq-${g}.git
 done
 
-/usr/bin/env pip install wheel
+/usr/bin/env pip install -U pip
+/usr/bin/env pip install -U wheel
+# Include an updated version of pip
+/usr/bin/env pip wheel --wheel-dir=$OQ_WHEEL pip
 /usr/bin/env pip wheel --wheel-dir=$OQ_WHEEL -r oq-engine/requirements-py35-${BUILD_OS}.txt
 /usr/bin/env pip install $OQ_WHEEL/*
  
 for g in hazardlib engine;
 do
-    /usr/bin/env pip wheel --no-deps oq-${g}/ -d $OQ_WHEEL
-    declare OQ_$(echo $g | tr '[:lower:]' '[:upper:]')_DEV=$(git -C oq-{g} rev-parse --short HEAD)
+    cd oq-${g}
+    /usr/bin/env pip wheel --no-deps . -w $OQ_WHEEL
+    declare OQ_$(echo $g | tr '[:lower:]' '[:upper:]')_DEV=$(git rev-parse --short HEAD)
+    cd ..
 done
 cp -R ${OQ_ROOT}/oq-engine/{README.md,LICENSE,demos,doc} ${OQ_ROOT}/dist
 rm -Rf $OQ_ROOT/dist/doc/sphinx

--- a/installers/unix/env/install.sh
+++ b/installers/unix/env/install.sh
@@ -67,7 +67,7 @@ fi
 FDEST=$(realpath "$DEST")
 
 echo "Creating a new python environment in $FDEST. Please wait."
-/usr/bin/python virtualenv/virtualenv.py $FDEST > /dev/null
+/usr/bin/env python3.5 -m venv $FDEST > /dev/null
 cp -R {README.md,LICENSE,demos,doc} $FDEST
 
 [ $MACOS ] && \
@@ -82,7 +82,7 @@ EOF
 
 source $FDEST/env.sh
 echo "Installing the files in $FDEST. Please wait."
-pip install wheelhouse/*.whl > /dev/null
+/usr/bin/env pip install wheelhouse/*.whl > /dev/null
 
 PROMPT="Do you want to make the 'oq' command available by default? [Y/n]: "
 read -e -p "$PROMPT" OQ

--- a/installers/unix/env/install.sh
+++ b/installers/unix/env/install.sh
@@ -22,6 +22,8 @@ if [ $GEM_SET_DEBUG ]; then
 fi
 set -e
 
+PYTHON=python3.5
+
 help() {
     cat <<HSD
 The command line arguments are as follows:
@@ -31,6 +33,15 @@ The command line arguments are as follows:
     -h, --help           This help
 HSD
     exit 0
+}
+
+check_dep() {
+    for i in $*; do
+        command -v $i &> /dev/null || {
+            echo -e "!! Please install $i first. Aborting." >&2
+            exit 1
+        }
+    done
 }
 
 realpath() {
@@ -59,6 +70,8 @@ while (( "$#" )); do
     shift
 done
 
+check_dep $PYTHON
+
 if [ -z $DEST ]; then
     PROMPT="Type the path where you want to install OpenQuake, followed by [ENTER]. Otherwise leave blank, it will be installed in $HOME/openquake: "
     read -e -p "$PROMPT" DEST
@@ -67,7 +80,7 @@ fi
 FDEST=$(realpath "$DEST")
 
 echo "Creating a new python environment in $FDEST. Please wait."
-/usr/bin/env python3.5 -m venv $FDEST > /dev/null
+/usr/bin/env $PYTHON -m venv $FDEST > /dev/null
 cp -R {README.md,LICENSE,demos,doc} $FDEST
 
 [ $MACOS ] && \

--- a/jenkins/Dockerfile.builder
+++ b/jenkins/Dockerfile.builder
@@ -1,1 +1,1 @@
-../installers/unix/opt/Dockerfile.builder
+../installers/unix/Dockerfile.builder


### PR DESCRIPTION
This allows creation of a standalone installer based on `venv` for Mac and Linux (>= CentOS 6)

Run: https://ci.openquake.org/job/builders/job/installers-builder/27/OS=macos_11/

Part of https://github.com/gem/oq-engine/issues/2803