### PR TITLE
Use Wine stable to build nsis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ script:
     - docker rmi openquake-centos7
     # NSIS installer
     - cd $TRAVIS_BUILD_DIR/installers/windows/nsis
-    - docker build --rm=true -t oq-nsis -f docker/Dockerfile .
-    - docker run --rm -t -i oq-nsis /opt/wine-stable/bin/wine python -c 'import pip; print(pip.__version__)'
-    - docker rmi oq-nsis
+    - docker build --rm=true -t f25-wine -f docker/Dockerfile .
+    - docker run --rm -t -i f25-wine /opt/wine-stable/bin/wine python -c 'import pip; print(pip.__version__)'
+    - docker rmi f25-wine

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ script:
     # NSIS installer
     - cd $TRAVIS_BUILD_DIR/installers/windows/nsis
     - docker build --rm=true -t oq-nsis -f docker/Dockerfile .
-    - docker run --rm -t -i oq-nsis /usr/bin/wine python -c 'import pip; print(pip.__version__)'
+    - docker run --rm -t -i oq-nsis /opt/wine-stable/bin/wine python -c 'import pip; print(pip.__version__)'
     - docker rmi oq-nsis

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -14,11 +14,11 @@ Microsoft Windows is not required.
 
 #### Build Docker image
 ```bash
-$ docker build --rm=true -t oq-nsis -f docker/Dockerfile .
+$ docker build --rm=true -t f25-wine -f docker/Dockerfile .
 ```
 ### Run the container
 ```bash
-$ docker run -v $(pwd):/io -t -i --rm oq-nsis
+$ docker run -v $(pwd):/io -t -i --rm f25-wine
 ```
 
 ### Manual installation 

--- a/installers/windows/nsis/docker/Dockerfile
+++ b/installers/windows/nsis/docker/Dockerfile
@@ -2,14 +2,12 @@
 FROM fedora:25
 MAINTAINER Daniele Viganò <daniele@openquake.org>
 
-ARG uid=1000
-
 RUN dnf -y install python-markdown python-wheel wget git zip unzip && \
     wget -qO- https://repos.wine-staging.com/wine/fedora/25/winehq.repo > /etc/yum.repos.d/winehq.repo && \
     dnf -y install wine-stable64
-    
 
-RUN useradd -u 1000 builder
+ARG uid=1000
+RUN useradd -u $uid builder
 
 USER builder
 ENV HOME /home/builder

--- a/installers/windows/nsis/docker/Dockerfile
+++ b/installers/windows/nsis/docker/Dockerfile
@@ -4,19 +4,23 @@ MAINTAINER Daniele Viganò <daniele@openquake.org>
 
 ARG uid=1000
 
-RUN dnf -y install wine python-markdown python-wheel wget git zip unzip
+RUN dnf -y install python-markdown python-wheel wget git zip unzip && \
+    wget -qO- https://repos.wine-staging.com/wine/fedora/25/winehq.repo > /etc/yum.repos.d/winehq.repo && \
+    dnf -y install wine-stable64
+    
 
 RUN useradd -u 1000 builder
 
 USER builder
 ENV HOME /home/builder
+ENV PATH /opt/wine-stable/bin:$PATH
 ENV WINEDEBUG -all 
 WORKDIR $HOME
 
 RUN wget -q https://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01-setup.exe && \
     wget -q https://www.python.org/ftp/python/2.7.13/python-2.7.13.amd64.msi && \
     pip wheel --disable-pip-version-check --no-deps wheel
-    
+
 RUN wineboot && sleep 10
 
 RUN wine nsis-3.01-setup.exe /S && \

--- a/installers/windows/nsis/docker/Dockerfile
+++ b/installers/windows/nsis/docker/Dockerfile
@@ -1,4 +1,5 @@
 # vi:syntax=dockerfile
+# name:f25-wine
 FROM fedora:25
 MAINTAINER Daniele Viganò <daniele@openquake.org>
 


### PR DESCRIPTION
Fedora is using a rolling version of Wine and the last update from v2.7 to v2.8 breaks Wine (at least in a Docker environment).

Here we are using them the stable version (2.0.1) from WineHQ official repo (https://wiki.winehq.org/Fedora)