### PR TITLE
Remove dup. code that is now included in oq-engine

### DIFF
--- a/installers/unix/env/build.sh
+++ b/installers/unix/env/build.sh
@@ -108,13 +108,7 @@ cp -R ${OQ_ROOT}/oq-engine/{README.md,LICENSE,demos,doc} ${OQ_ROOT}/dist
 rm -Rf $OQ_ROOT/dist/doc/sphinx
 
 # Make a zipped copy of each demo
-for d in hazard risk; do
-    cd ${OQ_ROOT}/dist/demos/${d}
-    for z in *; do
-        zip -q -r ${z}.zip $z
-    done
-    cd -
-done
+${OQ_ROOT}/oq-engine/helpers/zipdemos.sh ${OQ_ROOT}/dist/demos
 
 ## utils is not copied for now, since it does not contain anything useful here
 cp $OQ_DIR/install.sh ${OQ_ROOT}/dist

--- a/installers/unix/opt/build.sh
+++ b/installers/unix/opt/build.sh
@@ -188,13 +188,7 @@ cp -R oq-engine/doc $OQ_PREFIX/share/openquake/engine
 rm -Rf $OQ_PREFIX/share/openquake/engine/doc/sphinx
 
 # Make a zipped copy of each demo
-for d in hazard risk; do
-    cd ${OQ_PREFIX}/share/openquake/engine/demos/${d}
-    for z in *; do
-        zip -q -r ${z}.zip $z
-    done
-    cd -
-done
+oq-engine/helpers/zipdemos.sh ${OQ_PREFIX}/share/openquake/engine/demos
 
 # utils is not copied for now, since it does not contain anything useful here
 cp install.sh ${OQ_ROOT}/${OQ_REL}

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -42,6 +42,7 @@ wine pip -q install --disable-pip-version-check --force-reinstall --ignore-insta
 cd ..
 
 # Get the demo and the README
+cp -r src/oq-engine/demos .
 src/oq-engine/helpers/zipdemos.sh $(pwd)/demos
 
 python -m markdown src/oq-engine/README.md > README.html

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -42,14 +42,7 @@ wine pip -q install --disable-pip-version-check --force-reinstall --ignore-insta
 cd ..
 
 # Get the demo and the README
-cp -r src/oq-engine/demos .
-for d in hazard risk; do
-    cd demos/${d}
-    for z in *; do
-        zip -q -r ${z}.zip $z
-    done
-    cd -
-done
+src/oq-engine/helpers/zipdemos.sh $(pwd)/demos
 
 python -m markdown src/oq-engine/README.md > README.html
 


### PR DESCRIPTION
The functionality to zip demos is now included in `oq-engine` as an helper script. Remove duplication in the code. 