### PR TITLE
Stable build

### DIFF
--- a/installers/unix/env/README.md
+++ b/installers/unix/env/README.md
@@ -24,7 +24,7 @@ $ [GEM_SET_BRANCH='master'] bash /io/build.sh
 
 ## macOS
 
-Xcode and (Python 2.7)[https://www.python.org/ftp/python/2.17.13/python-2.7.13-macosx10.6.pkg] must be installed first
+Xcode, GNU sed and (Python 2.7)[https://www.python.org/ftp/python/2.17.13/python-2.7.13-macosx10.6.pkg] must be installed first
 
 ```bash
 ./build.sh
@@ -37,3 +37,4 @@ The following environment variables are understood by the script:
 - GEM_SET_DEBUG=<true|false>: enable debug (set -x)
 - GEM_SET_NPROC=n: it will pass 'n' to `make -j` (default is 2)
 - GEM_SET_BRANCH='branch': build the selected branch (by default is master)
+- GEM_SET_RELEASE=n: it set the builder to 'release mode'

--- a/installers/unix/env/build.sh
+++ b/installers/unix/env/build.sh
@@ -60,6 +60,10 @@ else
     TOOLS_BRANCH=$OQ_BRANCH
 fi
 
+if [[ $GEM_SET_RELEASE =~ ^[0-9]+$ ]]; then
+    PKG_REL=$GEM_SET_RELEASE
+fi
+
 if $(echo $OSTYPE | grep -q linux); then
     BUILD_OS='linux64'
     if [ -f /etc/redhat-release ]; then
@@ -113,7 +117,12 @@ git clone -q --depth=1 -b $TOOLS_BRANCH https://github.com/gem/oq-platform-taxon
  
 cd oq-engine
 /usr/bin/env pip -q wheel --no-deps . -w $OQ_WHEEL
-declare OQ_$(echo 'engine' | tr '[:lower:]' '[:upper:]')_DEV=$(git rev-parse --short HEAD)
+
+if [ $PKG_REL ]; then
+    OQ_VERSION="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")-${PKG_RELEASE}"
+else
+    OQ_VERSION=$(git rev-parse --short HEAD)
+fi
 cd ..
 
 mkdir ${OQ_WHEEL}/tools
@@ -131,6 +140,6 @@ ${OQ_ROOT}/oq-engine/helpers/zipdemos.sh ${OQ_DIST}/src/demos
 cp ${OQ_DIR}/install.sh ${OQ_DIST}
 
 echo "Creating installation package"
-makeself -q ${OQ_DIST} ${OQ_DIR}/openquake-py27-${BUILD_OS}-${OQ_ENGINE_DEV}.run "installer for the OpenQuake Engine" ./install.sh
+makeself -q ${OQ_DIST} ${OQ_DIR}/openquake-py27-${BUILD_OS}-${OQ_VERSION}.run "installer for the OpenQuake Engine" ./install.sh
 
 exit 0

--- a/installers/unix/env/build.sh
+++ b/installers/unix/env/build.sh
@@ -119,7 +119,7 @@ cd oq-engine
 /usr/bin/env pip -q wheel --no-deps . -w $OQ_WHEEL
 
 if [ $PKG_REL ]; then
-    OQ_VERSION="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")-${PKG_RELEASE}"
+    OQ_VERSION="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")-${PKG_REL}"
 else
     OQ_VERSION=$(git rev-parse --short HEAD)
 fi

--- a/installers/unix/opt/README.md
+++ b/installers/unix/opt/README.md
@@ -37,3 +37,4 @@ The following environment variables are understood by the script:
 - GEM_SET_DEBUG=<true|false>: enable debug (set -x)
 - GEM_SET_NPROC=n: it will pass 'n' to `make -j` (default is 2)
 - GEM_SET_BRANCH='branch': build the selected branch (by default is master)
+- GEM_SET_RELEASE=n: it set the builder to 'release mode'

--- a/installers/unix/opt/build.sh
+++ b/installers/unix/opt/build.sh
@@ -160,7 +160,7 @@ $OQ_PREFIX/bin/python2.7 -m pip -q wheel -r oq-engine/requirements-py27-${BUILD_
 cd oq-engine
 $OQ_PREFIX/bin/python2.7 -m pip -q wheel --no-deps . -w $OQ_WHEEL
 if [ $PKG_REL ]; then
-    OQ_VERSION="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")-${PKG_RELEASE}"
+    OQ_VERSION="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")-${PKG_REL}"
 else
     OQ_VERSION=$(git rev-parse --short HEAD)
 fi

--- a/installers/unix/opt/build.sh
+++ b/installers/unix/opt/build.sh
@@ -62,6 +62,10 @@ else
     TOOLS_BRANCH=$OQ_BRANCH
 fi
 
+if [[ $GEM_SET_RELEASE =~ ^[0-9]+$ ]]; then
+    PKG_REL=$GEM_SET_RELEASE
+fi
+
 if $(echo $OSTYPE | grep -q linux); then
     BUILD_OS='linux64'
     if [ -f /etc/redhat-release ]; then
@@ -155,7 +159,11 @@ $OQ_PREFIX/bin/python2.7 -m pip -q wheel -r oq-engine/requirements-py27-${BUILD_
 
 cd oq-engine
 $OQ_PREFIX/bin/python2.7 -m pip -q wheel --no-deps . -w $OQ_WHEEL
-declare OQ_$(echo 'engine' | tr '[:lower:]' '[:upper:]')_DEV=$(git rev-parse --short HEAD)
+if [ $PKG_REL ]; then
+    OQ_VERSION="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")-${PKG_RELEASE}"
+else
+    OQ_VERSION=$(git rev-parse --short HEAD)
+fi
 cd ..
 
 mkdir ${OQ_WHEEL}/tools
@@ -173,6 +181,6 @@ ${OQ_ROOT}/oq-engine/helpers/zipdemos.sh ${OQ_DIST}/src/demos
 cp ${OQ_DIR}/install.sh ${OQ_DIST}
 
 echo "Creating installation package"
-makeself -q ${OQ_DIST} ${OQ_DIR}/openquake-py27-${BUILD_OS}-${OQ_ENGINE_DEV}.run "installer for the OpenQuake Engine" ./install.sh
+makeself -q ${OQ_DIST} ${OQ_DIR}/openquake-py27-${BUILD_OS}-${OQ_VERSION}.run "installer for the OpenQuake Engine" ./install.sh
 
 exit 0

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -28,7 +28,7 @@ otherwise `master` is used.
 
 #### Release mode
 ```bash
-$ docker run -e GEM_SET_BRANCH=engine-X.Y -v $(pwd):/io -t -i --rm f26-wine /io/docker/build.sh -r Z
+$ docker run -e GEM_SET_BRANCH=engine-X.Y -e GEM_SET_RELEASE=Z -v $(pwd):/io -t -i --rm f26-wine /io/docker/build.sh
 ```
 where `Z` is the build number for the package. 
 

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -20,12 +20,17 @@ $ docker build --build-arg uid=$(id -u) --rm=true -t f26-wine -f docker/Dockerfi
 ```bash
 $ docker run -v $(pwd):/io -t -i --rm f26-wine
 ```
-
 #### Custom branches
 ```bash
 $ docker run -e GEM_SET_BRANCH=branch -e GEM_SET_BRANCH_TOOLS=branch -v $(pwd):/io -t -i --rm f26-wine
 ```
 otherwise `master` is used.
+
+#### Release mode
+```bash
+$ docker run -e GEM_SET_BRANCH=engine-X.Y -v $(pwd):/io -t -i --rm f26-wine /io/docker/build.sh -r Z
+```
+where `Z` is the build number for the package. 
 
 ### Manual installation 
 

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -93,7 +93,7 @@ ini_vers="$(cat src/oq-engine/openquake/baselib/__init__.py | sed -n "s/^__versi
 
 sed -i "s/\${MYVERSION}/$ini_vers/g" installer.nsi
 if [ $PKG_REL ]; then
-    sed -i "s/\${MYVERSION}/$PKG_REL/g" installer.nsi
+    sed -i "s/\${MYTIMESTAMP}/$PKG_REL/g" installer.nsi
 fi
 
 # Get the demo and the README

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -90,7 +90,7 @@ wine pip -q install --disable-pip-version-check --force-reinstall --ignore-insta
 cd $DIR
 
 ini_vers="$(cat src/oq-engine/openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
-git_time="$(git -C src/oq-engine log --format=%ct -1)"
+git_time="$(date -d @$(git -C src/oq-engine log --format=%ct -1) '+%y%m%d%H%M')"
 
 sed -i "s/\${MYVERSION}/$ini_vers/g" installer.nsi
 if [ $PKG_REL ]; then

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -90,10 +90,13 @@ wine pip -q install --disable-pip-version-check --force-reinstall --ignore-insta
 cd $DIR
 
 ini_vers="$(cat src/oq-engine/openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
+git_time="$(git -C src/oq-engine log --format=%ct -1)"
 
 sed -i "s/\${MYVERSION}/$ini_vers/g" installer.nsi
 if [ $PKG_REL ]; then
     sed -i "s/\${MYTIMESTAMP}/$PKG_REL/g" installer.nsi
+else
+    sed -i "s/\${MYTIMESTAMP}/$git_time/g" installer.nsi
 fi
 
 # Get the demo and the README

--- a/installers/windows/nsis/docker/build.sh
+++ b/installers/windows/nsis/docker/build.sh
@@ -34,12 +34,8 @@ else
     TOOLS_BRANCH=$OQ_BRANCH
 fi
 
-if [[ $1 == -r ]]; then
-    if [[ $2 =~ ^[0-9]+$ ]]; then
-          PKG_REL=$2
-    else
-        echo "Missing or bad release number"
-    fi
+if [[ $GEM_SET_RELEASE =~ ^[0-9]+$ ]]; then
+    PKG_REL=$GEM_SET_RELEASE
 fi
 
 # Default software distribution
@@ -94,12 +90,10 @@ wine pip -q install --disable-pip-version-check --force-reinstall --ignore-insta
 cd $DIR
 
 ini_vers="$(cat src/oq-engine/openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
-ini_maj="$(echo "$ini_vers" | sed -n 's/^\([0-9]\+\).*/\1/gp')"
-ini_min="$(echo "$ini_vers" | sed -n 's/^[0-9]\+\.\([0-9]\+\).*/\1/gp')"
 
 sed -i "s/\${MYVERSION}/$ini_vers/g" installer.nsi
 if [ $PKG_REL ]; then
-    sed -i "s/\${MYRELEASE}/$PKG_REL/g" installer.nsi
+    sed -i "s/\${MYVERSION}/$PKG_REL/g" installer.nsi
 fi
 
 # Get the demo and the README

--- a/installers/windows/nsis/installer.nsi
+++ b/installers/windows/nsis/installer.nsi
@@ -17,16 +17,15 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 !define /date MYTIMESTAMP "%y%m%d%H%M"
+!define MYVERSION "2.99.0" # OpenQuake 2 tree
 !define PRODUCT_NAME "OpenQuake Engine"
-!define VER_MAJOR "2"
-!define VER_MINOR "6"
-!define VER_REVISION "0"
+!define VER_CODE "2.7.0"
 !define VER_BUILD "${MYTIMESTAMP}"
-!define PRODUCT_VERSION "${VER_MAJOR}.${VER_MINOR}.${VER_REVISION}.${VER_BUILD}"
+!define PRODUCT_VERSION "${VER_CODE}.${VER_BUILD}"
 !define PUBLISHER "GEM Foundation"
 !define BITNESS "64"
 !define ARCH_TAG ""
-!define INSTALLER_NAME "OpenQuake_Engine_${VER_MAJOR}.${VER_MINOR}.${VER_REVISION}-${VER_BUILD}.exe"
+!define INSTALLER_NAME "OpenQuake_Engine_${VER_CODE}-${VER_BUILD}.exe"
 !define PRODUCT_ICON "openquake.ico"
 # WOW6432Node is needed because we are running 64bit software. It's hardcoded since we support only
 # installations on 64bit systems (code is 64bit only)
@@ -48,7 +47,7 @@ RequestExecutionLevel admin
 ; UI pages
 !insertmacro MUI_PAGE_WELCOME
 !insertmacro MUI_PAGE_LICENSE "LICENSE.txt"
-!ifdef VER_MAJOR & VER_MINOR & VER_REVISION & VER_BUILD
+!ifdef VER_CODE & VER_BUILD
 Page custom PageReinstall PageLeaveReinstall
 !endif
 !insertmacro MUI_PAGE_COMPONENTS
@@ -57,13 +56,13 @@ Page custom PageReinstall PageLeaveReinstall
 !insertmacro MUI_PAGE_FINISH
 !insertmacro MUI_LANGUAGE "English"
 
-!ifdef VER_MAJOR & VER_MINOR & VER_REVISION & VER_BUILD
+!ifdef VER_CODE & VER_BUILD
 VIAddVersionKey "CompanyName" "${PUBLISHER}"
 VIAddVersionKey "LegalCopyright" "https://github.com/gem/oq-engine/blob/master/LICENSE"
 VIAddVersionKey "FileDescription" "OpenQuake Setup"
 VIAddVersionKey "ProductName" "${PRODUCT_NAME}"
-VIAddVersionKey "ProductVersion" "${VER_MAJOR}.${VER_MINOR}.${VER_REVISION}"
-VIAddVersionKey "FileVersion" "${VER_MAJOR}.${VER_MINOR}.${VER_REVISION}"
+VIAddVersionKey "ProductVersion" "${VER_CODE}"
+VIAddVersionKey "FileVersion" "${VER_CODE}"
 VIProductVersion ${PRODUCT_VERSION}
 !endif
 
@@ -187,7 +186,7 @@ Section "Uninstall"
 SectionEnd
 
 
-!ifdef VER_MAJOR & VER_MINOR & VER_REVISION & VER_BUILD
+!ifdef VER_CODE & VER_BUILD
 
 Var ReinstallPageCheck
 
@@ -204,7 +203,7 @@ Function PageReinstall
   ReadRegDWORD $R3 HKLM "Software\${PRODUCT_NAME}" "VersionBuild"
   StrCpy $R0 $R0.$R1.$R2.$R3
 
-  ${VersionCompare} ${VER_MAJOR}.${VER_MINOR}.${VER_REVISION}.${VER_BUILD} $R0 $R0
+  ${VersionCompare} ${VER_CODE}.${VER_BUILD} $R0 $R0
   ${If} $R0 == 0
     StrCpy $R1 "${PRODUCT_NAME} ${PRODUCT_VERSION} is already installed. Select the operation you want to perform and click Next to continue."
     StrCpy $R2 "Add/Reinstall components"

--- a/installers/windows/nsis/installer.nsi
+++ b/installers/windows/nsis/installer.nsi
@@ -19,7 +19,7 @@
 !define /date MYTIMESTAMP "%y%m%d%H%M"
 !define MYVERSION "2.99.0" # OpenQuake 2 tree
 !define PRODUCT_NAME "OpenQuake Engine"
-!define VER_CODE "2.7.0"
+!define VER_CODE "${MYVERSION}"
 !define VER_BUILD "${MYTIMESTAMP}"
 !define PRODUCT_VERSION "${VER_CODE}.${VER_BUILD}"
 !define PUBLISHER "GEM Foundation"


### PR DESCRIPTION
Closes #43 and closes #63 

This is the last step to have a fully automatic delivery of stable installer. Jenkins has been updated accordingly.

https://ci.openquake.org/job/builders/job/installers-builder/48/
- openquake-py27-macos-2.7.0-1.run
- openquake-py27-linux64-2.7.0-1.run
- OpenQuake_Engine_2.7.0-1.exe