### PR TITLE
Since now we have Python 3.5 for RHEL use it in Docker

### DIFF
--- a/oq-docker/Dockerfile.centos
+++ b/oq-docker/Dockerfile.centos
@@ -5,8 +5,8 @@ MAINTAINER Daniele Viganò <daniele@openquake.org>
 ARG oq_branch=master
 ARG tools_branch=master
 
-RUN curl -so /etc/yum.repos.d/gem-openquake-python3-epel-7.repo \
-    https://copr.fedorainfracloud.org/coprs/gem/openquake-python3/repo/epel-7/gem-openquake-python3-epel-7.repo
+RUN curl -so /etc/yum.repos.d/gem-openquake-stable-epel-7.repo \
+    https://copr.fedorainfracloud.org/coprs/gem/openquake-stable/repo/epel-7/gem-openquake-stable-epel-7.repo
 RUN yum -q -y install oq-python35 && \
     yum -q -y clean all
 

--- a/oq-docker/Dockerfile.centos
+++ b/oq-docker/Dockerfile.centos
@@ -1,37 +1,28 @@
 # vi:syntax=dockerfile
-FROM centos:centos7
+FROM centos:7
 MAINTAINER Daniele Viganò <daniele@openquake.org>
 
 ARG oq_branch=master
 ARG tools_branch=master
 
-RUN yum -q -y install centos-release-scl curl
-# Using Python 3.6 here since Python 3.5 from SCL is too old
-# user should not care about what is running inside Docker
-RUN yum -q -y install rh-python36 && \
+RUN curl -so /etc/yum.repos.d/gem-openquake-python3-epel-7.repo \
+    https://copr.fedorainfracloud.org/coprs/gem/openquake-python3/repo/epel-7/gem-openquake-python3-epel-7.repo
+RUN yum -q -y install oq-python35 && \
     yum -q -y clean all
 
-RUN mkdir -p /opt/openquake/lib && \
-    ln -rs /opt/openquake/lib /opt/openquake/lib64
-
-ENV PATH /opt/openquake/bin/:/opt/rh/rh-python36/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH /opt/rh/rh-python36/root/usr/lib64
-ENV PYTHONPATH /opt/openquake/lib/python3.6/site-packages/
-
+ENV PATH /opt/openquake/bin:$PATH
 ADD https://api.github.com/repos/gem/oq-engine/git/refs/heads/$oq_branch /tmp/nocache.json
-RUN curl -so /opt/openquake/requirements.txt https://raw.githubusercontent.com/gem/oq-engine/$oq_branch/requirements-py36-linux64.txt && \
-    pip3 -q install -U pip  && \
-    pip3 -q install --force-reinstall --ignore-installed --upgrade --no-deps --prefix /opt/openquake -r /opt/openquake/requirements.txt && \
-    pip3 -q install --prefix /opt/openquake https://github.com/gem/oq-engine/archive/$oq_branch.zip && \
+RUN curl -so /opt/openquake/requirements.txt https://raw.githubusercontent.com/gem/oq-engine/$oq_branch/requirements-py35-linux64.txt && \
+    pip3 -q install -r /opt/openquake/requirements.txt && \
+    pip3 -q install https://github.com/gem/oq-engine/archive/$oq_branch.zip && \
     for app in oq-platform-standalone oq-platform-ipt oq-platform-taxtweb oq-platform-taxonomy; do \
         if curl --output /dev/null --silent --head --fail --location https://github.com/gem/${app}/archive/$tools_branch.zip ; then \
-           pip3 -q install --prefix /opt/openquake https://github.com/gem/${app}/archive/$tools_branch.zip; \
+           pip3 -q install https://github.com/gem/${app}/archive/$tools_branch.zip; \
         else \
-           pip3 -q install --prefix /opt/openquake https://github.com/gem/${app}/archive/master.zip; \
+           pip3 -q install https://github.com/gem/${app}/archive/master.zip; \
         fi \
     done
 
-ADD openquake/__init__.py $PYTHONPATH/openquake
 ADD oqrun.sh /opt/openquake/
 
 RUN useradd -u 1000 openquake


### PR DESCRIPTION
To be able to use Pyhton 3 in our Docker container with CentOS we were doing ugly things.

Now we can take the advantage of having our own Python 3.5 package and make code much, MUCH more clean and simpler.

https://ci.openquake.org/job/builders/job/docker-builder/103/