### PR TITLE
Save WebUI log as artifact

### DIFF
--- a/.github/workflows/windows_package.yml
+++ b/.github/workflows/windows_package.yml
@@ -103,9 +103,6 @@ jobs:
           ping 127.0.0.1 -n 6 > null
           oq.exe engine --list-risk-calculations
           curl.exe -v --fail -G http://127.0.0.1:8800/engine/1/outputs
-          # FIXME: the following causes a failure and we should see the webui log as a consequence
-          curl.exe -v --fail -G http://127.0.0.1:8800/engine/100/outputs
-          cat webui.log
       - name: Upload Artifact WebUI log
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/windows_package.yml
+++ b/.github/workflows/windows_package.yml
@@ -106,11 +106,12 @@ jobs:
           # FIXME: the following causes a failure and we should see the webui log as a consequence
           curl.exe -v http://127.0.0.1:8800/engine/100/outputs
           cat webui.log
-      - name: Display WebUI log in case of failure
-        if: ${{ failure() }}
-        run: |
-          Start-Sleep -Seconds 2
-          cat webui.log
+      - name: Upload Artifact WebUI log
+        uses: actions/upload-artifact@v3
+        with:
+          name: WebUI_log
+          path: webui.log
+          retention-days: 5
   Upload_Installer:
     needs: Test_OQ
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_package.yml
+++ b/.github/workflows/windows_package.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           $env:PATH += ";C:\Program Files\OpenQuake Engine\python3\Scripts"
           Write-Host ${env:PATH}
-          Start-Job -ScriptBlock{& 'C:\Program Files\OpenQuake Engine\python3\Scripts\oq.exe' webui start 127.0.0.1:8800 -s}
+          Start-Job -ScriptBlock{& 'C:\Program Files\OpenQuake Engine\python3\Scripts\oq.exe' webui start 127.0.0.1:8800 -s 1> webui.log 2>&1}
           ping 127.0.0.1 -n 6 > null
           Get-Job
           netstat -o -n -a | findstr 8800
@@ -103,6 +103,12 @@ jobs:
           ping 127.0.0.1 -n 6 > null
           oq.exe engine --list-risk-calculations
           curl.exe -v --fail -G http://127.0.0.1:8800/engine/1/outputs
+          curl.exe -v --fail -G http://127.0.0.1:8800/engine/100/outputs
+  Display_WebUI_log:
+    needs: Test_OQ
+    if: ${{ failure() }}
+    run: |
+        cat webui.log
   Upload_Installer:
     needs: Test_OQ
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_package.yml
+++ b/.github/workflows/windows_package.yml
@@ -102,9 +102,10 @@ jobs:
           curl.exe -X HEAD -I http://127.0.0.1:8800/taxtweb/
           ping 127.0.0.1 -n 6 > null
           oq.exe engine --list-risk-calculations
-          curl.exe -v --fail -G http://127.0.0.1:8800/engine/1/outputs
+          curl.exe -v http://127.0.0.1:8800/engine/1/outputs
           # FIXME: the following causes a failure and we should see the webui log as a consequence
-          curl.exe -v --fail -G http://127.0.0.1:8800/engine/100/outputs
+          curl.exe -v http://127.0.0.1:8800/engine/100/outputs
+          cat webui.log
       - name: Display WebUI log in case of failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/windows_package.yml
+++ b/.github/workflows/windows_package.yml
@@ -102,9 +102,9 @@ jobs:
           curl.exe -X HEAD -I http://127.0.0.1:8800/taxtweb/
           ping 127.0.0.1 -n 6 > null
           oq.exe engine --list-risk-calculations
-          curl.exe -v http://127.0.0.1:8800/engine/1/outputs
+          curl.exe -v --fail -G http://127.0.0.1:8800/engine/1/outputs
           # FIXME: the following causes a failure and we should see the webui log as a consequence
-          curl.exe -v http://127.0.0.1:8800/engine/100/outputs
+          curl.exe -v --fail -G http://127.0.0.1:8800/engine/100/outputs
           cat webui.log
       - name: Upload Artifact WebUI log
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows_package.yml
+++ b/.github/workflows/windows_package.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Display WebUI log in case of failure
         if: ${{ failure() }}
         run: |
+          Start-Sleep -Seconds 2
           cat webui.log
   Upload_Installer:
     needs: Test_OQ

--- a/.github/workflows/windows_package.yml
+++ b/.github/workflows/windows_package.yml
@@ -103,12 +103,12 @@ jobs:
           ping 127.0.0.1 -n 6 > null
           oq.exe engine --list-risk-calculations
           curl.exe -v --fail -G http://127.0.0.1:8800/engine/1/outputs
+          # FIXME: the following causes a failure and we should see the webui log as a consequence
           curl.exe -v --fail -G http://127.0.0.1:8800/engine/100/outputs
-  Display_WebUI_log:
-    needs: Test_OQ
-    if: ${{ failure() }}
-    run: |
-        cat webui.log
+      - name: Display WebUI log in case of failure
+        if: ${{ failure() }}
+        run: |
+          cat webui.log
   Upload_Installer:
     needs: Test_OQ
     runs-on: ubuntu-latest


### PR DESCRIPTION
The WebUI log is short, it requires very little space and it is retained for 5 days.
It is useful to display server side errors when our curls return just the status code.